### PR TITLE
Method added to remove multipath device

### DIFF
--- a/fibrechannel/fibrechannel.go
+++ b/fibrechannel/fibrechannel.go
@@ -17,9 +17,11 @@ package fibrechannel
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
+	"os/exec"
+
+	"github.com/golang/glog"
 
 	"errors"
 	"path"
@@ -312,4 +314,14 @@ func removeFromScsiSubsystem(deviceName string, io ioHandler) {
 	glog.Infof("fc: remove device from scsi-subsystem: path: %s", fileName)
 	data := []byte("1")
 	io.WriteFile(fileName, data, 0666)
+}
+
+func RemoveMultipathDevice(device string) error {
+	cmd := exec.Command("multipath", "-f", device)
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed remove multipath device: %s err: %v", device, err)
+	}
+	glog.Infof("output of multipath device remove command: %s", stdoutStderr)
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Currently no support available to remove Multipath device after the device is detached.
This PR adds support to remove the Multipath after the device is detached.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RemoveMultipathDevice method is added in fibre channel library to remove Multipaths after the device is detached
```
